### PR TITLE
Use `python -m pip` instead of `pip.exe` to upgrade `pip`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,9 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ env.python_version }}
-      - name: Install packages
-        run: pip install briefcase
+      - name: Install dependencies
+        run: |
+          python -m pip install briefcase
       - name: Build App
         run: |
           cd tests/apps/verify-${{ matrix.framework }}

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade setuptools wheel
-        pip install briefcase
+        python -m pip install --upgrade setuptools wheel
+        python -m pip install briefcase
     - name: Generate VisualStudio stub app
       run: |
         # Generate the stub app

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install --upgrade pip
+        python -m pip install --upgrade pip
         pip install --upgrade setuptools wheel
         pip install briefcase
     - name: Generate VisualStudio stub app


### PR DESCRIPTION
- `pip` cannot upgrade itself on Windows because a running exe cannot be replaced.
- See beeware/briefcase#923

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
