### PR TITLE
Optionally include author in installation path

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,9 +10,9 @@
     "description": "Short description of app",
     "guid": "1409c8f5-c276-4cf3-a2fd-defcbdfef9a2",
     "install_scope": "",
+    "use_full_install_path": true,
     "python_version": "3.X.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension"
-    ],
-    "use_full_install_path": true
+    ]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,5 +13,6 @@
     "python_version": "3.X.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension"
-    ]
+    ],
+    "use_full_install_path": true
 }

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -55,9 +55,13 @@
 
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder">
+            {%- if cookiecutter.use_full_install_path == "True" %}
                 <Directory Id="CompanyFolder" Name="{{ cookiecutter.author or 'Unknown Developer' }}">
                     <Directory Id="{{ cookiecutter.module_name }}_ROOTDIR" Name="{{ cookiecutter.formal_name }}" />
                 </Directory>
+            {%- else %}
+                <Directory Id="{{ cookiecutter.module_name }}_ROOTDIR" Name="{{ cookiecutter.formal_name }}" />
+            {%- endif %}
             </Directory>
 
             <Directory Id="ProgramMenuFolder">


### PR DESCRIPTION
There is now a new option `use_full_install_path` which defaults to `True` to install the application in `Programs/<author name>/<app name>`. If you include the option in the `pyproject.toml` with a value of `False`, it installs the application into `Programs/<app name>`.

See beeware/briefcase#1199

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
