### PR TITLE
Cleanup raw python executables.

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -14,3 +14,6 @@ support_path = "src"
 }.get(cookiecutter.python_version|py_tag, "") }}
 stub_binary_revision = 7
 icon = "icon.ico"
+cleanup_paths = [
+    "src/python*.exe",
+]


### PR DESCRIPTION
Adds `python.exe` and `pythonw.exe` to the default cleanup list for Window apps. 

This is required because command line installs add the app directory to the path; this means `python.exe` becomes visible (and may be preferred over other Python installs on a system).

Fixes beeware/briefcase#2139.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
