### PR TITLE
Add processing of .pth files from "app_packages".

### DIFF
--- a/{{ cookiecutter.format }}/src/sitecustomize.py
+++ b/{{ cookiecutter.format }}/src/sitecustomize.py
@@ -1,0 +1,18 @@
+# A site customization that processes .pth files from "app_packages".
+import os
+import sys
+import site
+
+# Add the "app_packages" directory to the path and process its .pth files.
+site.addsitedir(os.path.join(os.path.dirname(__file__), "app_packages"))
+
+# Call the next sitecustomize script if there is one
+# (https://nedbatchelder.com/blog/201001/running_code_at_python_startup.html).
+del sys.modules["sitecustomize"]
+this_dir = os.path.dirname(__file__)
+path_index = sys.path.index(this_dir)
+del sys.path[path_index]
+try:
+    import sitecustomize  # noqa: F401
+finally:
+    sys.path.insert(path_index, this_dir)


### PR DESCRIPTION
As described [here](https://github.com/beeware/briefcase/issues/2195#issuecomment-2727821874), the `app_packages` should be added via `site.addsitedir()` so that `.pth` files are executed correctly.

I tested it using a manually created `.pth` file that executed a `.py` file with a `print`. The output of the print was visible in the console with `briefcase run windows app`.

I also added `pywin32` as a dependency in my application and tested it with the following code:
```python
import win32ui
win32ui.MessageBox("I am working now", "Hello pywin32")
```

Should fix https://github.com/beeware/briefcase/issues/2195, https://github.com/beeware/briefcase/issues/835, https://github.com/beeware/briefcase/issues/669 and https://github.com/beeware/briefcase/issues/381 for "windows app".


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
