### PR TITLE
Drop Python 3.9, add 3.14.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
+        # Pygame and PySide6 haven't published 3.14 wheels yet.
+        exclude:
+          - python-version: "3.14"
+            framework: pyside6
+          - python-version: "3.14"
+            framework: pygame

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -6,16 +6,16 @@ target_version = "0.3.24"
 app_path = "src/app"
 app_packages_path = "src/app_packages"
 support_path = "src"
-{# Minor versions for 3.9, 3.10, and 3.11 cannot be bumped further -#}
+{# Minor versions for 3.10, 3.11, and 3.12 cannot be bumped further -#}
 {# since Python is not hosting embeddable zipped versions of them -#}
 {{ {
-    "3.9": "support_revision = 13",
     "3.10": "support_revision = 11",
     "3.11": "support_revision = 9",
     "3.12": "support_revision = 9",
-    "3.13": "support_revision = 3",
+    "3.13": "support_revision = 6",
+    "3.14": "support_revision = 0rc1",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = 9
+stub_binary_revision = 10
 icon = "icon.ico"
 {% for document_type_id, document_type in cookiecutter.document_types.items() -%}
 document_type_icon.{{ document_type_id }} = "{{ cookiecutter.app_name }}-{{ document_type_id }}.ico"


### PR DESCRIPTION
Python 3.9 is EOL; 3.14 is now available.

This won't pass CI until 3.14 binaries have been tagged.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
