### PR TITLE
Add handling for post-install and pre-uninstall scripts.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,6 +16,9 @@
     "package_path": "C:\\path\\to\\content",
     "binary_path": "{{ cookiecutter.formal_name }}.exe",
     "document_types": "",
+    "install_options": "",
+    "post_install_script": "",
+    "pre_uninstall_script": "",
     "python_version": "3.X.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -5,6 +5,7 @@ target_version = "0.3.24"
 [paths]
 app_path = "src/app"
 app_packages_path = "src/app_packages"
+install_scripts_path = "src/scripts"
 support_path = "src"
 {# Minor versions for 3.10, 3.11, and 3.12 cannot be bumped further -#}
 {# since Python is not hosting embeddable zipped versions of them -#}

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -1,4 +1,5 @@
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
     <Package
         UpgradeCode="{{ cookiecutter.guid }}"
         Name="{{ cookiecutter.formal_name }}"
@@ -153,8 +154,13 @@
         </Feature>
         {% endif %}
 
-        <!-- UI features are documented at https://docs.firegiant.com/wix3/wixui/, and
-        implemented in the WiX source code under src/ext/UI/wixlib.
+        <!-- UI features are documented at:
+
+           https://docs.firegiant.com/wix/tools/wixext/wixui/,
+
+        and implemented in the WiX source code:
+
+           https://github.com/wixtoolset/wix/tree/HEAD/src/ext/UI/wixlib
 
         We implement our own UI flow by linking together individual dialogs. There are
         some pre-defined UI flows such as WixUI_Advanced, but they don't allow much
@@ -166,7 +172,26 @@
         <WixVariable Id="WixUISupportPerMachine" Value="1" />
         <Property Id="WixAppFolder" Value="WixPerUserFolder" />
 
+        <!-- Customize the images in the installer -->
+        <!-- <WixVariable Id="WixUIBannerBMP" Value="wix-banner-493x58.bmp" /> -->
+        <!-- <WixVariable Id="WixUIDialogBMP" Value="wix-dialog-493x312.bmp" /> -->
+
+        <!-- Define the license text-->
+        <WixVariable Id="WixUILicenseRtf" Value="src/LICENSE.rtf" />
+
+        <!-- Custom user properties -->
+        <!-- To set the initial value of the property to OFF, don't define it -->
+        {% for name, install_option in cookiecutter.install_options.items() %}
+        {% if not install_option.default %}<!--{% endif %}<Property Id="OPTION_{{ name.upper() }}" Value="1"/>{% if not install_option.default %}-->{% endif %}
+        {% endfor %}
+
         <UI>
+            <!-- Include the common WixUI resources-->
+            <UIRef Id="WixUI_Common" />
+
+            <!-- Include translations for error text (see https://stackoverflow.com/questions/44161526) -->
+            <UIRef Id="WixUI_ErrorProgressText" />
+
             <!-- Include all TextStyles from WixUI_Advanced -->
             <TextStyle
                 Id="WixUI_Font_Normal"
@@ -188,24 +213,45 @@
                 Bold="yes" />
             <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
 
-            <!-- Include all DialogRefs from WixUI_Advanced. These include:
+            <!-- Define the custom Install Options dialog -->
+            <Dialog Id="InstallOptionsDlg" Width="370" Height="270" Title="!(loc.CustomizeDlg_Title)">
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.CustomizeDlgBannerBitmap)" />
+                <Control Id="Title" Type="Text" X="15" Y="6" Width="210" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.CustomizeDlgTitle)" />
+                <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Select optional features for the install" />
+                <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="373" Height="0" />
 
-            * Child dialogs launched from top-level dialogs.
-            * Dialogs implicitly shown at particular points in the install, determined
-              either by their IDs, or the InstallUISequence in their source code. -->
-            <DialogRef Id="BrowseDlg" />
-            <DialogRef Id="DiskCostDlg" />
-            <DialogRef Id="ErrorDlg" />
-            <DialogRef Id="FatalError" />
-            <DialogRef Id="FilesInUse" />
-            <DialogRef Id="MsiRMFilesInUse" />
-            <DialogRef Id="PrepareDlg" />
-            <DialogRef Id="ProgressDlg" />
-            <DialogRef Id="ResumeDlg" />
-            <DialogRef Id="UserExit" />
-            <DialogRef Id="WelcomeDlg" />
+            {% for name, install_option in cookiecutter.install_options.items() %}
+                {% set y_pos = 55 + loop.index0 * 20 %}
+                <Control
+                    Id="Option_{{ name }}_check"
+                    X="50" Y="{{ y_pos }}" Width="200" Height="17"
+                    Type="CheckBox"
+                    Property="OPTION_{{ name.upper() }}"
+                    CheckBoxValue="1"
+                    Text="{{ install_option.description }}" />
+            {% endfor %}
 
-            <!-- Scope handling has to work within the following constraints, some of
+                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="373" Height="0" />
+                <Control Id="Back" Type="PushButton" X="192" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
+                <Control Id="Next" Type="PushButton" X="248" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)">
+                    <Subscribe Event="SelectionNoItems" Attribute="Enabled" />
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+                    <Publish Event="SpawnDialog" Value="CancelDlg" />
+                </Control>
+            </Dialog>
+
+            <!-- Define the workflow through the dialogs.
+
+            The general workflow is:
+             * Welcome
+             * License
+             * (optional) Install Scope (see notes below)
+             * (optional) Install options
+             * Verify Ready
+             * Exit
+
+            Scope handling has to work within the following constraints, some of
             which are documented, and some not
             (https://learn.microsoft.com/en-us/windows/win32/msi/single-package-authoring):
 
@@ -238,34 +284,39 @@
               * Per-user: ALLUSERS="", MSIINSTALLPERUSER=1
               * Per machine: ALLUSERS=1, MSIINSTALLPERUSER="" -->
 
+            <!-- Initial welcome dialog -->
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg" />
+
+            <!-- License agreement -->
+            <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" />
+
             {% if cookiecutter.install_scope != "perUserOrMachine" %}
             <!-- The scope is pre-determined, and the properties have already been set
             to the correct values by the <Package> Scope attribute. -->
-            <Publish
-                Dialog="WelcomeDlg"
-                Control="Next"
-                Event="EndDialog"
-                Value="Return" />
+                {% if cookiecutter.install_options %}
+            <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="InstallOptionDlg" Condition='LicenseAccepted = "1"'/>
 
+            <!-- Install Options -->
+            <Publish Dialog="InstallOptionsDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg" />
+            <Publish Dialog="InstallOptionsDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" />
+
+            <!-- Verify -->
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallOptionsDlg" Order="1" />
+                {% else %}
+            <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Condition='LicenseAccepted = "1"'/>
+
+            <!-- Verify -->
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallOptionsDlg" Order="1" />
+                {% endif %}
             {% else %}
             <!-- Let the user choose the scope. -->
-            <Publish
-                Dialog="WelcomeDlg"
-                Control="Next"
-                Event="NewDialog"
-                Value="InstallScopeDlg" />
 
-            <Publish
-                Dialog="InstallScopeDlg"
-                Control="Back"
-                Event="NewDialog"
-                Value="WelcomeDlg" />
+            <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="InstallScopeDlg" Condition='LicenseAccepted = "1"'/>
 
             <!-- Per-user scope. Although this is the default, we still need code to set
             it, because if we add more dialogs it will become possible to go back and
             change the setting. -->
-            <Publish
-                Dialog="InstallScopeDlg"
+            <Publish Dialog="InstallScopeDlg"
                 Control="Next"
                 Order="1"
                 Condition='WixAppFolder = "WixPerUserFolder"'
@@ -278,7 +329,7 @@
                 Condition='WixAppFolder = "WixPerUserFolder"'
                 Property="MSIINSTALLPERUSER"
                 Value="1" />
-            {% if cookiecutter.console_app %}
+                {% if cookiecutter.console_app %}
             <Publish
                 Dialog="InstallScopeDlg"
                 Control="Next"
@@ -293,7 +344,7 @@
                 Condition='WixAppFolder = "WixPerUserFolder"'
                 Event="Remove"
                 Value="MachinePathEnvFeature" />
-            {% endif %}
+                {% endif %}
 
             <!-- Per-machine scope -->
             <Publish
@@ -310,7 +361,7 @@
                 Condition='WixAppFolder = "WixPerMachineFolder"'
                 Property="MSIINSTALLPERUSER"
                 Value="{}" />
-            {% if cookiecutter.console_app %}
+                {% if cookiecutter.console_app %}
             <Publish
                 Dialog="InstallScopeDlg"
                 Control="Next"
@@ -325,35 +376,58 @@
                 Condition='WixAppFolder = "WixPerMachineFolder"'
                 Event="Remove"
                 Value="UserPathEnvFeature" />
+                {% endif %}
+
+            <!-- Install scope -->
+            <Publish Dialog="InstallScopeDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg" />
+
+                {% if cookiecutter.install_options %}
+            <Publish Dialog="InstallScopeDlg" Control="Next" Event="NewDialog" Value="InstallOptionsDlg" Order="99"/>
+
+            <!-- Install Options -->
+            <Publish Dialog="InstallOptionsDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg" />
+            <Publish Dialog="InstallOptionsDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" />
+
+            <!-- Verify -->
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallOptionsDlg" Order="1" />
+                {% else %}
+            <Publish Dialog="InstallScopeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="99"/>
+
+            <!-- Verify -->
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg" Order="1" />
+                {% endif %}
             {% endif %}
 
-            <Publish
-                Dialog="InstallScopeDlg"
-                Control="Next"
-                Order="99"
-                Event="EndDialog"
-                Value="Return" />
-
-            {% endif %}
-
-            <!-- Move FindRelatedProducts after the configuration dialogs to ensure it
-            searches the configured scope. This comes after the LaunchConditions action,
-            so downgrades will no longer be blocked in the UI phase, but that's OK
-            because LaunchConditions will run again in the execution phase. -->
-            <InstallUISequence>
-                <FindRelatedProducts After="ProgressDlg" />
-            </InstallUISequence>
-
-            <Publish
-                Dialog="ExitDialog"
-                Control="Finish"
-                Event="EndDialog"
-                Value="Return"
-                Order="999" />
+            <!-- Install complete -->
+            <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="99" />
         </UI>
 
-        <!-- Include necessary strings (https://stackoverflow.com/questions/44161526) -->
-        <UIRef Id="WixUI_ErrorProgressText" />
-        <UIRef Id="WixUI_Common" />
+        {% if cookiecutter.post_install_script %}
+        <!-- Post-install and Pre-uninstall scripts -->
+        <CustomAction
+            Id="PostInstallAction"
+            Directory="INSTALLFOLDER"
+            ExeCommand="[SystemFolder]cmd.exe /c &quot;[INSTALLFOLDER]scripts\post_install.bat&quot; --allusers=[ALLUSERS]{% for name in cookiecutter.install_options.keys() %} --{{ name }}=[OPTION_{{ name.upper() }}]{% endfor %}"
+            Execute="immediate"
+            Return="check"
+            Impersonate="no"/>
+        {% endif %}
+        {% if cookiecutter.pre_uninstall_script %}
+        <CustomAction
+            Id="PreUninstallAction"
+            Directory="INSTALLFOLDER"
+            ExeCommand="[SystemFolder]cmd.exe /c &quot;[INSTALLFOLDER]scripts\pre_uninstall.bat&quot;"
+            Execute="immediate"
+            Return="check"
+            Impersonate="no"/>
+        {% endif %}
+        <InstallExecuteSequence>
+        {% if cookiecutter.post_install_script %}
+            <Custom Action="PostInstallAction" After="InstallFinalize" Condition="NOT Installed" />
+        {% endif %}
+        {% if cookiecutter.pre_uninstall_script %}
+            <Custom Action="PreUninstallAction" After="InstallInitialize" Condition='REMOVE="ALL"'/>
+        {% endif %}
+        </InstallExecuteSequence>
     </Package>
 </Wix>


### PR DESCRIPTION
Adds extension points to allow for the injection of a post-install or pre-uninstall script, and for options in the installer.

The value of the pre/post install script doesn't matter for the template; it's treated as a boolean.

The installer options is a list of dictionaries, with 2 keys of significance:
- name: the identifier that is used to 
- description: A short description of the option
- default: true/false

If the configuration defines an option with a name of `foo`, the `OPTION_FOO` property can be used to programmatically drive the installer.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
