### PR TITLE
Bump the 3.13 and 3.14 support packages

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -12,8 +12,8 @@ support_path = "src"
     "3.10": "support_revision = 11",
     "3.11": "support_revision = 9",
     "3.12": "support_revision = 9",
-    "3.13": "support_revision = 6",
-    "3.14": "support_revision = '0rc1'",
+    "3.13": "support_revision = 8",
+    "3.14": "support_revision = 0",
 }.get(cookiecutter.python_version|py_tag, "") }}
 stub_binary_revision = 10
 icon = "icon.ico"


### PR DESCRIPTION
Bump the 3.13 and 3.14 support packages after the release of 3.13.8 and 3.14.0.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
