### PR TITLE
Use ComponentGuidGenerationSeed to prevent shared component GUIDs across products

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -40,7 +40,7 @@
             {%- if cookiecutter.use_full_install_path %}
             <Directory Name="{{ (cookiecutter.author or 'Unknown Developer')|xml_escape }}">
             {%- endif %}
-            <Directory Id="INSTALLFOLDER" Name="{{ cookiecutter.formal_name|xml_escape }}" />
+            <Directory Id="INSTALLFOLDER" Name="{{ cookiecutter.formal_name|xml_escape }}" ComponentGuidGenerationSeed="{{ cookiecutter.guid }}" />
             {%- if cookiecutter.use_full_install_path %}
             </Directory>
             {%- endif %}


### PR DESCRIPTION
## Background
WiX generates deterministic component GUIDs based on the target directory ID and relative file path. Since all products using this template share the same directory ID (INSTALLFOLDER) and file structure (e.g., extras/**), they receive identical component GUIDs.

When multiple MSI products are installed based on **the same template:**
1. Each install registers the same component GUID with Windows Installer
2. Reference counting sees multiple "clients" for each component
3. On uninstall, Windows Installer refuses to remove components because "another client exists"
4. Files remain on disk after uninstall

This fix adds `ComponentGuidGenerationSeed="{{ cookiecutter.guid }}"` to the `INSTALLFOLDER` directory element, seeding component GUID generation with the product's UpgradeCode so each product gets unique GUIDs.

## Diagnosis

The issue was identified by first discovering files remained on disk after uninstall. Using verbose MSI logging (`msiexec /x installer.msi /l*v log.txt`), revealed:
```
MSI (s) (40:D4) [06:41:10:101]: Disallowing uninstallation of component: {<a long GUID>} since another client exists
MSI (s) (40:D4) [06:41:10:101]: Disallowing uninstallation of component: {<a long GUID>} since another client exists
<and many more>
```

I confirmed that multiple products were registered to the same component GUIDs by querying the Windows Installer registry:
```
$componentsPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components"
Get-ChildItem $componentsPath | ForEach-Object {
    $component = $_.PSChildName
    $products = (Get-Item $_.PSPath).Property
    if ($products.Count -gt 1) {
        foreach ($product in $products) {
            $keyPath = (Get-ItemProperty $_.PSPath).$product
            Write-Host "Component: $component | Products: $($products.Count) | KeyPath: $keyPath"
        }
    }
}
```
This revealed components with `Products: 2`, confirming shared GUIDs across different MSI products.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested - note that I have only tested this locally by identifying the issue, apply the change, verify that the change fixes my issue.
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
