### PR TITLE
Bump support packages and stub binary 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
       python-version: ${{ matrix.python-version }}
-      runner-os: windows-latest
+      runner-os: ${{ matrix.runs-on }}
       framework: ${{ matrix.framework }}
       target-platform: Windows
       target-format: app
@@ -40,12 +40,21 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
-        # Pygame and PySide6 haven't published 3.14 wheels yet.
-        # Toga is waiting on a release of Python.net for 3.14
+        runs-on: ["windows-latest", "windows-11-arm"]
         exclude:
-          - python-version: "3.14"
-            framework: pyside6
+          # Github Actions doesn't provide Windows/ARM64 builds for Python 3.10
+          - python-version: "3.10"
+            runs-on: "windows-11-arm"
+          # Pygame hasn't published 3.14 wheels.
           - python-version: "3.14"
             framework: pygame
+          # Pygame hasn't published any Windows/ARM64 wheels.
+          - framework: pygame
+            runs-on: windows-11-arm
+          # Toga is waiting on a release of Python.net for 3.14
           - python-version: "3.14"
             framework: toga
+          # Toga tests won't run on Windows/ARM64 until
+          # https://github.com/actions/partner-runner-images/issues/174 is resolved
+          - framework: "toga"
+            runs-on: windows-11-arm

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -12,11 +12,11 @@ extras_path = "extras"
 {{ {
     "3.10": "support_revision = 11",
     "3.11": "support_revision = 9",
-    "3.12": "support_revision = 9",
-    "3.13": "support_revision = 8",
-    "3.14": "support_revision = 0",
+    "3.12": "support_revision = 10",
+    "3.13": "support_revision = 13",
+    "3.14": "support_revision = 4",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = 10
+stub_binary_revision = 11
 icon = "icon.ico"
 {% for document_type_id, document_type in cookiecutter.document_types.items() -%}
 document_type_icon.{{ document_type_id }} = "{{ cookiecutter.app_name }}-{{ document_type_id }}.ico"


### PR DESCRIPTION
* Bumps stub binary to b11, adding ARM64 support.
* Updates support packages
* Adds CI to test ARM64 builds.

# PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
