### PR TITLE
Allow installer banner and splash background images to be customized.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -23,6 +23,10 @@
   "install_options": "",
   "uninstall_options": "",
   "installer_path": "_installer",
+  "installer_images": {
+    "background": "",
+    "banner": ""
+  },
   "post_install_script": "",
   "pre_uninstall_script": "",
   "python_version": "3.X.0",

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -284,8 +284,12 @@
         <Property Id="WixAppFolder" Value="WixPerUserFolder" />
 
         <!-- Customize the images in the installer -->
-        <!-- <WixVariable Id="WixUIBannerBMP" Value="wix-banner-493x58.bmp" /> -->
-        <!-- <WixVariable Id="WixUIDialogBMP" Value="wix-dialog-493x312.bmp" /> -->
+        {% if cookiecutter.installer_images.banner %}
+        <WixVariable Id="WixUIBannerBmp" Value="\\?\{{ cookiecutter.installer_images.banner|xml_escape }}" />
+        {% endif %}
+        {% if cookiecutter.installer_images.background %}
+        <WixVariable Id="WixUIDialogBmp" Value="\\?\{{ cookiecutter.installer_images.background|xml_escape }}" />
+        {% endif %}
 
         <!-- Define the license text-->
         <WixVariable Id="WixUILicenseRtf" Value="LICENSE.rtf" />


### PR DESCRIPTION
MSI installers have two customizable images:

* The image shown as the background of the first page of the installer
* The banner image used on the top of every subsequent page of the installer.

This PR allows those two images to be customised. If a path isn't provided as part of the template context, the default images are used.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
