### PR TITLE
Prompt to close apps locking files

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -301,6 +301,10 @@
             <!-- Include translations for error text (see https://stackoverflow.com/questions/44161526) -->
             <UIRef Id="WixUI_ErrorProgressText" />
 
+            <!-- Prompt to close apps locking files (see https://stackoverflow.com/a/710685) -->
+            <DialogRef Id="FilesInUse" />
+            <DialogRef Id="MsiRMFilesInUse" />
+
             <!-- Include all TextStyles from WixUI_Advanced -->
             <TextStyle
                 Id="WixUI_Font_Normal"


### PR DESCRIPTION
This makes the installer prompt to close any apps locking installation files.

## References

https://stackoverflow.com/a/710685
https://docs.firegiant.com/wix3/wixui/dialog_reference/wixui_dialogs/
https://learn.microsoft.com/en-us/windows/win32/msi/system-reboots

## Screenshots

<img width="490" height="382" alt="Screenshot 2026-05-27 185251" src="https://github.com/user-attachments/assets/03d6824a-0b86-44d6-8370-928749372481" />


In case of failures:

<img width="488" height="374" alt="Screenshot 2026-05-27 185306" src="https://github.com/user-attachments/assets/8dea3560-a09c-4b25-9359-772d96dd7bbd" />

## Context

We made some customizations to the Wix template for Anki and I'm working on contributing generic improvements: https://github.com/ankitects/anki/issues/4765

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool

