### PR TITLE
Miscellaneous improvements to MSI installers

### DIFF
--- a/{{ cookiecutter.format }}/extras/{{ cookiecutter.installer_path }}/run_post_install.bat
+++ b/{{ cookiecutter.format }}/extras/{{ cookiecutter.installer_path }}/run_post_install.bat
@@ -2,8 +2,9 @@
 setlocal enabledelayedexpansion
 SET ALLUSERS=%1
 SET INSTALLER_PATH=%2
+SET INSTALLER_UNATTENDED=%3
 {% for name in cookiecutter.install_options -%}
-{%- set argn = loop.index + 2 -%}
+{%- set argn = loop.index + 3 -%}
 SET OPTION_{{ name.upper() }}=%{{ argn }}
 {% endfor -%}
 

--- a/{{ cookiecutter.format }}/extras/{{ cookiecutter.installer_path }}/run_pre_uninstall.bat
+++ b/{{ cookiecutter.format }}/extras/{{ cookiecutter.installer_path }}/run_pre_uninstall.bat
@@ -1,7 +1,9 @@
 @echo off
 setlocal enabledelayedexpansion
+SET INSTALLER_UNATTENDED=%1
 {% for name in cookiecutter.uninstall_options -%}
-SET OPTION_{{ name.upper() }}=%{{ loop.index }}
+{%- set argn = loop.index + 1 -%}
+SET OPTION_{{ name.upper() }}=%{{ argn }}
 {% endfor -%}
 
 CALL "%~dp0pre_uninstall.bat"

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -915,29 +915,80 @@
         <!-- Post-install and Pre-uninstall scripts -->
         <!-- Execute="deferred" runs in server process where Impersonate="no" takes effect -->
         <!-- This ensures scripts run with elevated privileges for per-machine installs -->
+        <SetProperty
+            Id="POST_INSTALL_CMD"
+            Value="&quot;[SystemFolder]cmd.exe&quot; /c &quot;&quot;[INSTALLFOLDER]{{ cookiecutter.installer_path }}\run_post_install.bat&quot; [OPTION_ALLUSERS] &quot;[OriginalDatabase]&quot; [INSTALL_UNATTENDED]{% for name in cookiecutter.install_options %} [OPTION_{{ name.upper() }}]{% endfor %}&quot;"
+            After="CostFinalize"
+            Sequence="execute"
+            Condition="NOT Installed" />
+
         <CustomAction
-            Id="PostInstallAction"
+            Id="PostInstallActionInteractive"
             Directory="INSTALLFOLDER"
-            ExeCommand="[SystemFolder]cmd.exe /c &quot;&quot;[INSTALLFOLDER]{{ cookiecutter.installer_path }}\run_post_install.bat&quot; [OPTION_ALLUSERS] &quot;[OriginalDatabase]&quot; [INSTALL_UNATTENDED]{% for name in cookiecutter.install_options %} [OPTION_{{ name.upper() }}]{% endfor %}&quot;"
+            ExeCommand="[POST_INSTALL_CMD]"
+            Execute="deferred"
+            Return="check"
+            Impersonate="no"/>
+
+        <CustomAction
+            Id="SetPostInstallQuietCmd"
+            Property="PostInstallActionQuiet"
+            Value="[POST_INSTALL_CMD]"
+            Execute="immediate"/>
+
+        <CustomAction
+            Id="PostInstallActionQuiet"
+            BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
+            DllEntry="WixQuietExec"
             Execute="deferred"
             Return="check"
             Impersonate="no"/>
         {% endif %}
         {% if cookiecutter.pre_uninstall_script %}
+        <SetProperty
+            Id="PRE_UNINSTALL_CMD"
+            Value="&quot;[SystemFolder]cmd.exe&quot;  /c &quot;&quot;[INSTALLFOLDER]{{ cookiecutter.installer_path }}\run_pre_uninstall.bat&quot; [INSTALL_UNATTENDED]{% for name in cookiecutter.uninstall_options %} [OPTION_{{ name.upper() }}]{% endfor %}&quot;"
+            After="CostFinalize"
+            Sequence="execute"
+            Condition='REMOVE="ALL"' />
+
         <CustomAction
-            Id="PreUninstallAction"
+            Id="PreUninstallActionInteractive"
             Directory="INSTALLFOLDER"
-            ExeCommand="[SystemFolder]cmd.exe /c &quot;&quot;[INSTALLFOLDER]{{ cookiecutter.installer_path }}\run_pre_uninstall.bat&quot;{% for name in cookiecutter.uninstall_options %} [OPTION_{{ name.upper() }}]{% endfor %}&quot;"
+            ExeCommand="[PRE_UNINSTALL_CMD]"
+            Execute="deferred"
+            Return="check"
+            Impersonate="no"/>
+
+        <CustomAction
+            Id="SetPreUninstallQuietCmd"
+            Property="PreUninstallActionQuiet"
+            Value="[PRE_UNINSTALL_CMD]"
+            Execute="immediate"/>
+        <CustomAction
+            Id="PreUninstallActionQuiet"
+            BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)"
+            DllEntry="WixQuietExec"
             Execute="deferred"
             Return="check"
             Impersonate="no"/>
         {% endif %}
         <InstallExecuteSequence>
         {% if cookiecutter.post_install_script %}
-            <Custom Action="PostInstallAction" Before="InstallFinalize" Condition="NOT Installed" />
+            <!-- Interactive install -->
+            <Custom Action="PostInstallActionInteractive" Before="InstallFinalize" Condition='NOT Installed AND INSTALL_UNATTENDED = "0"' />
+
+            <!-- Quiet install -->
+            <Custom Action="SetPostInstallQuietCmd" Before="PostInstallActionQuiet" Condition='NOT Installed AND INSTALL_UNATTENDED = "1"' />
+            <Custom Action="PostInstallActionQuiet" Before="InstallFinalize" Condition='NOT Installed AND INSTALL_UNATTENDED = "1"' />
         {% endif %}
         {% if cookiecutter.pre_uninstall_script %}
-            <Custom Action="PreUninstallAction" After="InstallInitialize" Condition='REMOVE="ALL"'/>
+            <!-- Interactive uninstall -->
+            <Custom Action="PreUninstallActionInteractive" After="InstallInitialize" Condition='REMOVE="ALL" AND INSTALL_UNATTENDED = "0"' />
+
+            <!-- Quiet uninstall -->
+            <Custom Action="SetPreUninstallQuietCmd" Before="PreUninstallActionQuiet" Condition='REMOVE="ALL" AND INSTALL_UNATTENDED = "1"' />
+            <Custom Action="PreUninstallActionQuiet" After="InstallInitialize" Condition='REMOVE="ALL" AND INSTALL_UNATTENDED = "1"' />
         {% endif %}
         </InstallExecuteSequence>
     </Package>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -332,6 +332,82 @@
                 Size="!(loc.Advanced_Font_Emphasized_Size)"
                 Bold="yes" />
             <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
+
+            <!-- Define a custom InstallDirDlg so we can add a "Disk Usage" button
+                 to the bottom button row. The layout is otherwise identical to
+                 the standard InstallDirDlg -->
+            <Dialog
+                Id="CustomInstallDirDlg"
+                Width="370" Height="270"
+                Title="!(loc.InstallDirDlg_Title)">
+
+                <Control
+                    Id="BannerBitmap"
+                    Type="Bitmap"
+                    X="0" Y="0" Width="370" Height="44"
+                    TabSkip="no"
+                    Text="!(loc.InstallDirDlgBannerBitmap)" />
+                <Control
+                    Id="Title"
+                    Type="Text"
+                    X="15" Y="6" Width="200" Height="15"
+                    Transparent="yes"
+                    NoPrefix="yes"
+                    Text="!(loc.InstallDirDlgTitle)" />
+                <Control
+                    Id="Description"
+                    Type="Text"
+                    X="25" Y="23" Width="280" Height="15"
+                    Transparent="yes"
+                    NoPrefix="yes"
+                    Text="!(loc.InstallDirDlgDescription)" />
+                <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="373" Height="0" />
+
+                <Control
+                    Id="FolderLabel"
+                    Type="Text"
+                    X="20" Y="60" Width="290" Height="30"
+                    NoPrefix="yes"
+                    Text="!(loc.InstallDirDlgFolderLabel)" />
+                <Control
+                    Id="Folder"
+                    Type="PathEdit"
+                    X="20" Y="100" Width="320" Height="18"
+                    Property="WIXUI_INSTALLDIR"
+                    Indirect="yes" />
+                <Control
+                    Id="ChangeFolder"
+                    Type="PushButton"
+                    X="20" Y="120" Width="56" Height="17"
+                    Text="!(loc.InstallDirDlgChange)" />
+
+                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="373" Height="0" />
+                <Control
+                    Id="DiskUsage"
+                    Type="PushButton"
+                    X="112" Y="243" Width="56" Height="17"
+                    Text="Disk &amp;Usage" />
+                <Control
+                    Id="Back"
+                    Type="PushButton"
+                    X="180" Y="243" Width="56" Height="17"
+                    Text="!(loc.WixUIBack)" />
+                <Control
+                    Id="Next"
+                    Type="PushButton"
+                    X="236" Y="243" Width="56" Height="17"
+                    Default="yes"
+                    Text="!(loc.WixUINext)" />
+                <Control
+                    Id="Cancel"
+                    Type="PushButton"
+                    X="304" Y="243" Width="56" Height="17"
+                    Cancel="yes"
+                    Text="!(loc.WixUICancel)">
+                    <Publish Event="SpawnDialog" Value="CancelDlg" />
+                </Control>
+            </Dialog>
+
             {% if cookiecutter.install_options %}
             <!-- Define the custom Install Options dialog -->
             <Dialog
@@ -542,12 +618,12 @@
                 Dialog="LicenseAgreementDlg"
                 Control="Next"
                 Event="NewDialog"
-                Value="InstallDirDlg"
+                Value="CustomInstallDirDlg"
                 Condition='LicenseAccepted = "1"'/>
 
             <!-- Install Dir -->
             <Publish
-                Dialog="InstallDirDlg"
+                Dialog="CustomInstallDirDlg"
                 Control="Back"
                 Event="NewDialog"
                 Value="LicenseAgreementDlg" />
@@ -555,7 +631,7 @@
                 {% if cookiecutter.install_options %}
 
             <Publish
-                Dialog="InstallDirDlg"
+                Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
                 Value="InstallOptionsDlg" />
@@ -565,7 +641,7 @@
                 Dialog="InstallOptionsDlg"
                 Control="Back"
                 Event="NewDialog"
-                Value="InstallDirDlg" />
+                Value="CustomInstallDirDlg" />
             <Publish
                 Dialog="InstallOptionsDlg"
                 Control="Next"
@@ -583,7 +659,7 @@
                 {% else %}
 
             <Publish
-                Dialog="InstallDirDlg"
+                Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
                 Value="VerifyReadyDlg" />
@@ -593,7 +669,7 @@
                 Dialog="VerifyReadyDlg"
                 Control="Back"
                 Event="NewDialog"
-                Value="InstallDirDlg"
+                Value="CustomInstallDirDlg"
                 Order="1"
                 Condition="NOT Installed" />
                 {% endif %}
@@ -683,12 +759,12 @@
                 Dialog="InstallScopeDlg"
                 Control="Next"
                 Event="NewDialog"
-                Value="InstallDirDlg"
+                Value="CustomInstallDirDlg"
                 Order="99"/>
 
             <!-- Install Dir -->
             <Publish
-                Dialog="InstallDirDlg"
+                Dialog="CustomInstallDirDlg"
                 Control="Back"
                 Event="NewDialog"
                 Value="InstallScopeDlg" />
@@ -696,7 +772,7 @@
                 {% if cookiecutter.install_options %}
 
             <Publish
-                Dialog="InstallDirDlg"
+                Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
                 Value="InstallOptionsDlg" />
@@ -706,7 +782,7 @@
                 Dialog="InstallOptionsDlg"
                 Control="Back"
                 Event="NewDialog"
-                Value="InstallDirDlg" />
+                Value="CustomInstallDirDlg" />
             <Publish
                 Dialog="InstallOptionsDlg"
                 Control="Next"
@@ -723,7 +799,7 @@
                 Condition="NOT Installed" />
                 {% else %}
             <Publish
-                Dialog="InstallDirDlg"
+                Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
                 Value="VerifyReadyDlg"
@@ -734,7 +810,7 @@
                 Dialog="VerifyReadyDlg"
                 Control="Back"
                 Event="NewDialog"
-                Value="InstallDirDlg"
+                Value="CustomInstallDirDlg"
                 Order="1"
                 Condition="NOT Installed" />
                 {% endif %}
@@ -743,18 +819,24 @@
             <!-- Display the BrowseDlg when the "Change" button on InstallDirDlg
             is pressed. -->
             <Publish
-                Dialog="InstallDirDlg"
+                Dialog="CustomInstallDirDlg"
                 Control="ChangeFolder"
                 Event="[_BrowseProperty]"
                 Value="[WIXUI_INSTALLDIR]"
                 Order="1"/>
             <Publish
-                Dialog="InstallDirDlg"
+                Dialog="CustomInstallDirDlg"
                 Control="ChangeFolder"
                 Event="SpawnDialog"
                 Value="BrowseDlg"
                 Order="2"/>
-
+            <!-- Display the standard DiskCostDlg (provided by WixUI_Common)
+            when the "Disk Usage" button on CustomInstallDirDlg is pressed. -->
+            <Publish
+                Dialog="CustomInstallDirDlg"
+                Control="DiskUsage"
+                Event="SpawnDialog"
+                Value="DiskCostDlg" />
 
             <!-- Define the workflow through the uninstall dialogs.
 

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -209,6 +209,17 @@
             Sequence="execute"
             Condition="ALLUSERS = 1" />
 
+        <!--
+          If the installer is running in "quiet" mode (UILevel < 3), it must be treated as unattended.
+          -->
+        <Property Id="INSTALL_UNATTENDED" Value="0"/>
+        <SetProperty
+            Id="INSTALL_UNATTENDED"
+            Value="1"
+            After="CostFinalize"
+            Sequence="execute"
+            Condition="UILevel &lt; 3" />
+
         {% if cookiecutter.console_app %}
         <!-- If a Level evaluates to 0 at the start of either the UI or the execution
         phase, then the feature cannot be re-enabled by any means, not even the ADDLOCAL
@@ -825,7 +836,7 @@
         <CustomAction
             Id="PostInstallAction"
             Directory="INSTALLFOLDER"
-            ExeCommand="[SystemFolder]cmd.exe /c &quot;&quot;[INSTALLFOLDER]{{ cookiecutter.installer_path }}\run_post_install.bat&quot; [OPTION_ALLUSERS] &quot;[OriginalDatabase]&quot;{% for name in cookiecutter.install_options %} [OPTION_{{ name.upper() }}]{% endfor %}&quot;"
+            ExeCommand="[SystemFolder]cmd.exe /c &quot;&quot;[INSTALLFOLDER]{{ cookiecutter.installer_path }}\run_post_install.bat&quot; [OPTION_ALLUSERS] &quot;[OriginalDatabase]&quot; [INSTALL_UNATTENDED]{% for name in cookiecutter.install_options %} [OPTION_{{ name.upper() }}]{% endfor %}&quot;"
             Execute="deferred"
             Return="check"
             Impersonate="no"/>


### PR DESCRIPTION
Three improvements to MSI operation.

1. A `INSTALLER_UNATTENDED` environment variable is exposed to post-install and pre-uninstall scripts, allowing scripts to identify if they're running in quiet mode.
2. When running in quiet mode, post-install and pre-uninstall scripts no longer cause a console window to be displayed.
3. A disk space requirements tool has been added to the installer.

Refs beeware/briefcase#2853.

briefcase-repo: https://github.com/freakboy3742/briefcase
briefcase-ref: msi-improvements

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Opus 4.7
