### PR TITLE
Check Windows build number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,22 @@ jobs:
     with:
       pre-commit-source: pre-commit
 
+  verify-min-os-version:
+    name: Verify min_os_version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: |
+          target_windows_build=$(grep -oP 'target_windows_build = \K\d+' "{{ cookiecutter.format }}/briefcase.toml")
+          min_os_version=$(grep -oP '"min_os_version": "\K\d+(?=")' "cookiecutter.json")
+          if [ "$target_windows_build" -ne "$min_os_version" ]; then
+              echo "::error::$target_windows_build != $min_os_version"
+              exit 1
+          fi
+
   verify-apps:
     name: Build apps
-    needs: pre-commit
+    needs: [pre-commit, verify-min-os-version]
     uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
       python-version: ${{ matrix.python-version }}

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -32,6 +32,7 @@
   "python_version": "3.X.0",
   "host_arch": "AMD64",
   "vscode_platform": "{{ 'ARM64' if cookiecutter.host_arch == 'ARM64' else 'x64' }}",
+  "min_os_version": "",
   "_extensions": [
     "briefcase.integrations.cookiecutter.PythonVersionExtension",
     "briefcase.integrations.cookiecutter.UUIDExtension",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -32,7 +32,7 @@
   "python_version": "3.X.0",
   "host_arch": "AMD64",
   "vscode_platform": "{{ 'ARM64' if cookiecutter.host_arch == 'ARM64' else 'x64' }}",
-  "min_os_version": "",
+  "min_os_version": "10240",
   "_extensions": [
     "briefcase.integrations.cookiecutter.PythonVersionExtension",
     "briefcase.integrations.cookiecutter.UUIDExtension",

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -1,6 +1,8 @@
 # Generated using Python {{ cookiecutter.python_version }}
 [briefcase]
 target_version = "0.3.24"
+# Windows 10
+target_windows_build = 10240
 
 [paths]
 app_path = "src/app"

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -35,6 +35,15 @@
         override that with our own definition to avoid confusion. -->
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
+        {% if cookiecutter.min_os_version %}
+        <Property Id="WINDOWSBUILDNUMBER" Secure="yes">
+            <RegistrySearch Id="BuildNumberSearch" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="CurrentBuildNumber" Type="raw" />
+        </Property>
+        <Launch
+            Condition="Installed OR (VersionNT64 AND (WINDOWSBUILDNUMBER &gt;= {{ cookiecutter.min_os_version }}))"
+            Message="This application requires Windows build {{ cookiecutter.min_os_version }} or later." />
+        {% endif %}
+
         {% if cookiecutter.dotnet_version %}
         <netfx:DotNetCompatibilityCheck
             Property="DOTNETRUNTIMECHECK"


### PR DESCRIPTION
This adds a check for the Windows build number (using `min_os_version`) before installation.

Briefcase PR: https://github.com/beeware/briefcase/pull/2855

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
