### PR TITLE
Add a check for path length limits on install.

### DIFF
--- a/{{ cookiecutter.format }}/extras/{{ cookiecutter.installer_path }}/check_path_len.js
+++ b/{{ cookiecutter.format }}/extras/{{ cookiecutter.installer_path }}/check_path_len.js
@@ -1,0 +1,159 @@
+// Validate that the selected INSTALLFOLDER is short enough to accommodate
+// every file this MSI is about to install, given the Windows MAX_PATH
+// limit of 260 characters (32767 if long paths are enabled)
+//
+// Outputs (set on the running MSI session):
+//
+//   INSTALLDIR_TOO_LONG       "1" if the selected path is too long, else ""
+//   INSTALLDIR_TOO_LONG_MSG   A human-readable diagnostic message,
+//                             populated whether or not the check failed
+
+// Windows MAX_PATH minus the null terminator.
+var MAX_PATH_LEN = 259;
+var LONG_PATH_LEN = 32766;
+
+try {
+    var shell = new ActiveXObject("WScript.Shell");
+    var enabled = shell.RegRead(
+        "HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem\\LongPathsEnabled");
+    if (enabled === 1 || enabled === "1") {
+        MAX_PATH_LEN = LONG_PATH_LEN;
+    }
+} catch (e) {
+    // Key missing or unreadable — fall through to the conservative limit.
+}
+
+var MSG_INFO = 0x04000000;  // INSTALLMESSAGE_INFO
+
+var installFolder = Session.Property("INSTALLFOLDER");
+
+// INSTALLFOLDER is always set with a trailing backslash by MSI. Strip it
+// for length accounting; we add exactly one separator below when joining
+// to the relative path.
+if (installFolder.charAt(installFolder.length - 1) === "\\") {
+    installFolder = installFolder.substring(0, installFolder.length - 1);
+}
+
+// --------------------------------------------------------------------------
+// Build a map of Directory id -> resolved relative path from INSTALLFOLDER.
+//
+// The Directory table is a tree. Each row has:
+//   Directory          - the row's id
+//   Directory_Parent   - parent row's id (NULL for the root)
+//   DefaultDir         - the directory name, possibly in the form
+//                        "shortname|longname" or
+//                        "targetshort:sourceshort|targetlong:sourcelong"
+//
+// We resolve each id by walking up to INSTALLFOLDER, collecting long names.
+// Directories above INSTALLFOLDER (e.g. ProgramFiles64Folder, TARGETDIR)
+// don't contribute to the relative path, since they are subsumed by the
+// user's selection.
+// --------------------------------------------------------------------------
+
+var dirParent = {};
+var dirName = {};
+
+var view = Session.Database.OpenView(
+    "SELECT `Directory`, `Directory_Parent`, `DefaultDir` FROM `Directory`");
+view.Execute();
+while (true) {
+    var rec = view.Fetch();
+    if (rec === null) {
+        break;
+    }
+    var id = rec.StringData(1);
+    dirParent[id] = rec.StringData(2);
+
+    var raw = rec.StringData(3);
+    // Pick the long name half of "short|long" if present.
+    var pipe = raw.indexOf("|");
+    var longPart = pipe >= 0 ? raw.substring(pipe + 1) : raw;
+    // Pick the target half of "target:source" if present.
+    var colon = longPart.indexOf(":");
+    if (colon >= 0) {
+        longPart = longPart.substring(0, colon);
+    }
+    dirName[id] = longPart;
+}
+
+// Resolve a directory id to its path relative to INSTALLFOLDER.
+// Returns "" for INSTALLFOLDER itself, and null for ids outside its subtree.
+function relPath(dirId) {
+    var parts = "";
+    var current = dirId;
+    while (true) {
+        if (current === "INSTALLFOLDER") {
+            return parts;
+        }
+        if (!dirParent.hasOwnProperty(current)) {
+            // Walked off the top without finding INSTALLFOLDER.
+            return null;
+        }
+        var name = dirName[current];
+        if (name !== "." && name !== "") {
+            parts = parts === "" ? name : name + "\\" + parts;
+        }
+        current = dirParent[current];
+    }
+}
+
+// --------------------------------------------------------------------------
+// Walk the File table, computing each file's full path relative to
+// INSTALLFOLDER and tracking the maximum length.
+// --------------------------------------------------------------------------
+
+var longestLen = 0;
+var longestPath = "";
+
+view = Session.Database.OpenView(
+    "SELECT `File`.`FileName`, `Component`.`Directory_` "
+    + "FROM `File`, `Component` "
+    + "WHERE `File`.`Component_` = `Component`.`Component`");
+view.Execute();
+while (true) {
+    var fileRec = view.Fetch();
+    if (fileRec === null) {
+        break;
+    }
+
+    var fileRaw = fileRec.StringData(1);
+    var filePipe = fileRaw.indexOf("|");
+    var fileLong = filePipe >= 0 ? fileRaw.substring(filePipe + 1) : fileRaw;
+
+    var dirRel = relPath(fileRec.StringData(2));
+    if (dirRel !== null) {
+        var candidate = dirRel === "" ? fileLong : dirRel + "\\" + fileLong;
+        if (candidate.length > longestLen) {
+            longestLen = candidate.length;
+            longestPath = candidate;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// Compare against the limit and publish the result.
+// --------------------------------------------------------------------------
+
+var totalLen = installFolder.length + 1 + longestLen;  // +1 for joining "\"
+var budget = MAX_PATH_LEN - longestLen - 1;
+var msg;
+
+if (totalLen > MAX_PATH_LEN) {
+  msg = "The selected install location is too long.\r\n\r\n"
+        + "Hello World must be intalled into a location with a maximum\r\n"
+        + "path length of " + budget + " characters. The selected path has a length\r\n"
+        + "of " + installFolder.length + " characters. Please select a shorter install location.\r\n";
+    Session.Property("INSTALLDIR_TOO_LONG") = "1";
+} else {
+    msg = "Install path length OK: " + totalLen + " of " + MAX_PATH_LEN
+        + " characters used (longest internal path: " + longestLen + ").";
+    Session.Property("INSTALLDIR_TOO_LONG") = "";
+}
+
+Session.Property("INSTALLDIR_TOO_LONG_MSG") = msg;
+
+// Always write to the MSI log, regardless of UI level.
+var logRec = Installer.CreateRecord(1);
+logRec.StringData(0) = "Briefcase install path check: [1]";
+logRec.StringData(1) = msg;
+Session.Message(MSG_INFO, logRec);

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -35,6 +35,22 @@
         override that with our own definition to avoid confusion. -->
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
+        <!-- Embed the install-path-length validation script. -->
+        <Binary
+            Id="CheckPathLen"
+            SourceFile="extras\_installer\check_path_len.js" />
+
+        <CustomAction
+            Id="CheckInstallDirLength"
+            BinaryRef="CheckPathLen"
+            JScriptCall=""
+            Execute="immediate"
+            Return="ignore" />
+
+        <CustomAction
+            Id="FailIfPathTooLong"
+            Error="[INSTALLDIR_TOO_LONG_MSG]" />
+
         {% if cookiecutter.min_os_version %}
         <Property Id="WINDOWSBUILDNUMBER" Secure="yes">
             <RegistrySearch Id="BuildNumberSearch" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="CurrentBuildNumber" Type="raw" />
@@ -566,6 +582,29 @@
             </Dialog>
             {% endif %}
 
+            <!-- Define the custom error dialog for long install paths -->
+            <Dialog
+                Id="PathTooLongDlg"
+                Width="270" Height="100"
+                Title="Install path too long">
+
+                <Control
+                    Id="Message"
+                    Type="Text"
+                    X="20" Y="10" Width="330" Height="60"
+                    NoPrefix="yes"
+                    Text="[INSTALLDIR_TOO_LONG_MSG]" />
+                <Control
+                    Id="OK"
+                    Type="PushButton"
+                    X="204" Y="73" Width="56" Height="17"
+                    Default="yes"
+                    Cancel="yes"
+                    Text="!(loc.WixUIOK)">
+                    <Publish Event="EndDialog" Value="Return" />
+                </Control>
+            </Dialog>
+
             <!-- Define the workflow through the install dialogs.
 
             The general workflow is:
@@ -641,13 +680,15 @@
                 Event="NewDialog"
                 Value="LicenseAgreementDlg" />
 
-                {% if cookiecutter.install_options %}
+                    {% if cookiecutter.install_options %}
 
             <Publish
                 Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
-                Value="InstallOptionsDlg" />
+                Value="InstallOptionsDlg"
+                Condition='INSTALLDIR_TOO_LONG &lt;&gt; "1"'
+                Order="99" />
 
             <!-- Install Options -->
             <Publish
@@ -669,13 +710,16 @@
                 Value="InstallOptionsDlg"
                 Order="1"
                 Condition="NOT Installed" />
+
                 {% else %}
 
             <Publish
                 Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
-                Value="VerifyReadyDlg" />
+                Value="VerifyReadyDlg"
+                Condition='INSTALLDIR_TOO_LONG &lt;&gt; "1"'
+                Order="99" />
 
             <!-- Verify -->
             <Publish
@@ -685,6 +729,7 @@
                 Value="CustomInstallDirDlg"
                 Order="1"
                 Condition="NOT Installed" />
+
                 {% endif %}
             {% else %}
             <!-- Let the user choose the scope. -->
@@ -712,6 +757,7 @@
                 Condition='WixAppFolder = "WixPerUserFolder"'
                 Property="MSIINSTALLPERUSER"
                 Value="1" />
+
                 {% if cookiecutter.console_app %}
             <Publish
                 Dialog="InstallScopeDlg"
@@ -744,6 +790,7 @@
                 Condition='WixAppFolder = "WixPerMachineFolder"'
                 Property="MSIINSTALLPERUSER"
                 Value="{}" />
+
                 {% if cookiecutter.console_app %}
             <Publish
                 Dialog="InstallScopeDlg"
@@ -759,6 +806,7 @@
                 Condition='WixAppFolder = "WixPerMachineFolder"'
                 Event="Remove"
                 Value="UserPathEnvFeature" />
+
                 {% endif %}
 
             <!-- Install scope -->
@@ -788,7 +836,9 @@
                 Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
-                Value="InstallOptionsDlg" />
+                Value="InstallOptionsDlg"
+                Condition='INSTALLDIR_TOO_LONG &lt;&gt; "1"'
+                Order="99" />
 
             <!-- Install Options -->
             <Publish
@@ -810,13 +860,16 @@
                 Value="InstallOptionsDlg"
                 Order="1"
                 Condition="NOT Installed" />
+
                 {% else %}
+
             <Publish
                 Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
                 Value="VerifyReadyDlg"
-                Order="99"/>
+                Condition='INSTALLDIR_TOO_LONG &lt;&gt; "1"'
+                Order="99" />
 
             <!-- Verify -->
             <Publish
@@ -826,6 +879,7 @@
                 Value="CustomInstallDirDlg"
                 Order="1"
                 Condition="NOT Installed" />
+
                 {% endif %}
             {% endif %}
 
@@ -843,6 +897,24 @@
                 Event="SpawnDialog"
                 Value="BrowseDlg"
                 Order="2"/>
+
+            <!-- Run the path-length check, then show the error dialog
+                 if the path is too long. The "good" path is handled
+                 -->
+            <Publish
+                Dialog="CustomInstallDirDlg"
+                Control="Next"
+                Event="DoAction"
+                Value="CheckInstallDirLength"
+                Order="1" />
+            <Publish
+                Dialog="CustomInstallDirDlg"
+                Control="Next"
+                Event="SpawnDialog"
+                Value="PathTooLongDlg"
+                Condition='INSTALLDIR_TOO_LONG = "1"'
+                Order="2" />
+
             <!-- Display the standard DiskCostDlg (provided by WixUI_Common)
             when the "Disk Usage" button on CustomInstallDirDlg is pressed. -->
             <Publish
@@ -988,6 +1060,11 @@
         {% endif %}
         <InstallExecuteSequence>
         {% if cookiecutter.post_install_script %}
+            <!-- Validate install path length. Runs after CostFinalize so
+                 INSTALLFOLDER is fully resolved.  -->
+            <Custom Action="CheckInstallDirLength" After="CostFinalize" Condition="NOT Installed" />
+            <Custom Action="FailIfPathTooLong" After="CheckInstallDirLength" Condition='NOT Installed AND INSTALLDIR_TOO_LONG = "1"' />
+
             <!-- Interactive install -->
             <Custom Action="PostInstallActionInteractive" Before="InstallFinalize" Condition='NOT Installed AND INSTALL_UNATTENDED = "0"' />
 


### PR DESCRIPTION
Adds a check that the installed content won't exceed known paths length limits at time of install.

This is implemented by way of a Javascript payload that is included in the template; it runs in the context of the MSI installer, so it has access to the MSI database. It interrogates the database to determine the longest path of installed content, and appends that to the INSTALLFOLDER from the current session. If that exceeds the 260 character limit, it sets a variable in the MSI session that is used to trigger a dialog (or throws an error in the install log in quiet mode). The dialog is displayed when the user presses "next" on the file path selection dialog, and advises the selected and maximum install path length that is allowed based on the content being installed.

The 260 character limit is enforced by default; however, if the user has long file path support enabled in the registry, the limit is raised to 32767.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Opus 4.7
