### PR TITLE
Fix different MSI builds with same version not triggering removal of existing installation

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -13,6 +13,8 @@
 
         <Media Id="1" Cabinet="product.cab" EmbedCab="yes" />
 
+        <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+
         <Icon Id="ProductIcon" SourceFile="icon.ico" />
 
         <!-- Add/Remove Programs settings -->

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -13,7 +13,10 @@
 
         <Media Id="1" Cabinet="product.cab" EmbedCab="yes" />
 
-        <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+        <MajorUpgrade
+            DowngradeErrorMessage="A newer version of [ProductName] is already installed."
+            AllowSameVersionUpgrades="yes"
+            Schedule="afterInstallInitialize" />
 
         <Icon Id="ProductIcon" SourceFile="icon.ico" />
 


### PR DESCRIPTION
## Problem

If you build two identical MSIs (technically only changing PackageCode, which is handled by Wix), install one package then install the second on top of that, you'll notice that surprisingly you now have two copies of the app installed.

## Solution

This is never obvious, but it turned out that adding a [MajorUpgrade](https://docs.firegiant.com/wix/schema/wxs/majorupgrade/) element is required.


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Sonnet 4.6
