### PR TITLE
Add an option to create a desktop shortcut

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,6 +16,7 @@
   "package_path": "C:\\path\\to\\content",
   "binary_path": "{{ cookiecutter.formal_name }}.exe",
   "install_launcher": true,
+  "create_desktop_shortcut": false,
   "document_types": "",
   "dotnet_version": "",
   "dotnet_runtime_type": "{{ 'Core' if cookiecutter.console_app else 'Desktop' }}",

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -1,10 +1,13 @@
+{%- set formal_name = cookiecutter.formal_name|xml_escape %}
+{%- set author = (cookiecutter.author or 'Unknown Developer')|xml_escape %}
+{%- set description = cookiecutter.description | truncate(256, False) %}
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
      xmlns:netfx="http://wixtoolset.org/schemas/v4/wxs/netfx"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
     <Package
         UpgradeCode="{{ cookiecutter.guid }}"
-        Name="{{ cookiecutter.formal_name|xml_escape }}"
+        Name="{{ formal_name }}"
         Version="{{ cookiecutter.version_triple }}"
         Manufacturer="{{ (cookiecutter.author or 'Anonymous')|xml_escape }}"
         Language="1033"
@@ -61,9 +64,9 @@
         depending on the values of the ALLUSERS and MSIINSTALLPERUSER properties. -->
         <StandardDirectory Id="ProgramFiles64Folder">
             {%- if cookiecutter.use_full_install_path %}
-            <Directory Name="{{ (cookiecutter.author or 'Unknown Developer')|xml_escape }}">
+            <Directory Name="{{ author }}">
             {%- endif %}
-            <Directory Id="INSTALLFOLDER" Name="{{ cookiecutter.formal_name|xml_escape }}" />
+            <Directory Id="INSTALLFOLDER" Name="{{ formal_name }}" />
             {%- if cookiecutter.use_full_install_path %}
             </Directory>
             {%- endif %}
@@ -103,17 +106,17 @@
 
         {% if cookiecutter.install_launcher -%}
         <StandardDirectory Id="ProgramMenuFolder">
-            <Directory Id="ProgramMenuSubfolder" Name="{{ cookiecutter.formal_name|xml_escape }}">
+            <Directory Id="ProgramMenuSubfolder" Name="{{ formal_name }}">
                 <Component Id="ApplicationShortcuts">
                     <Shortcut
                         Id="ApplicationShortcut1"
-                        Name="{{ cookiecutter.formal_name|xml_escape }}"
+                        Name="{{ formal_name }}"
                         Icon="ProductIcon"
-                        Description="{{ cookiecutter.description | truncate(256, False) }}"
+                        Description="{{ description }}"
                         Target="[INSTALLFOLDER]{{ cookiecutter.binary_path }}" />
                     <RegistryValue
                         Root="HKMU"
-                        Key="Software\{{ (cookiecutter.author or 'Unknown Developer')|xml_escape }}\{{ cookiecutter.formal_name|xml_escape }}"
+                        Key="Software\{{ author }}\{{ formal_name }}"
                         Name="installed"
                         Type="integer"
                         Value="1"
@@ -129,13 +132,13 @@
             <Component Id="DesktopShortcut">
                 <Shortcut
                     Id="DesktopShortcut1"
-                    Name="{{ cookiecutter.formal_name|xml_escape }}"
+                    Name="{{ formal_name }}"
                     Icon="ProductIcon"
-                    Description="{{ cookiecutter.description | truncate(256, False) }}"
+                    Description="{{ description }}"
                     Target="[INSTALLFOLDER]{{ cookiecutter.binary_path }}" />
                 <RegistryValue
                     Root="HKMU"
-                    Key="Software\{{ (cookiecutter.author or 'Unknown Developer')|xml_escape }}\{{ cookiecutter.formal_name|xml_escape }}"
+                    Key="Software\{{ author }}\{{ formal_name }}"
                     Name="desktop_shortcut_installed"
                     Type="integer"
                     Value="1"
@@ -177,7 +180,7 @@
 
         <Feature
             Id="DefaultFeature"
-            Title="{{ cookiecutter.formal_name|xml_escape }}"
+            Title="{{ formal_name }}"
             Description="Required application files"
             Display="expand"
         >

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -127,7 +127,6 @@
         </StandardDirectory>
         {%- endif %}
 
-        {% if cookiecutter.create_desktop_shortcut -%}
         <StandardDirectory Id="DesktopFolder">
             <Component Id="DesktopShortcut">
                 <Shortcut
@@ -145,7 +144,6 @@
                     KeyPath="yes" />
             </Component>
         </StandardDirectory>
-        {%- endif %}
 
         {% if cookiecutter.document_types -%}
         <SetProperty
@@ -196,7 +194,6 @@
             {%- endfor %}
         </Feature>
 
-        {% if cookiecutter.create_desktop_shortcut -%}
         <Feature
             Id="DesktopShortcutFeature"
             Title="Desktop Shortcut"
@@ -206,7 +203,6 @@
             <Level Condition="DESKTOP_SHORTCUT &lt;&gt; &quot;1&quot;" Value="0" />
             <ComponentRef Id="DesktopShortcut" />
         </Feature>
-        {%- endif %}
 
         <!-- Custom user properties
 
@@ -241,14 +237,12 @@
             Condition="OPTION_{{ name.upper() }} &lt;&gt; &quot;1&quot;" />
         {% endfor %}
 
+        <Property Id="DESKTOP_SHORTCUT" Value="1" />
+
         <!--
           The ALLUSERS variable has to have a value of "" or 1; we need a
           value of 0 or 1 for option output purposes.
           -->
-        {% if cookiecutter.create_desktop_shortcut -%}
-        <Property Id="DESKTOP_SHORTCUT" Value="1" />
-        {%- endif %}
-
         <Property Id="OPTION_ALLUSERS" Value="0"/>
         <SetProperty
             Id="OPTION_ALLUSERS"
@@ -433,15 +427,13 @@
                     X="20" Y="120" Width="56" Height="17"
                     Text="!(loc.InstallDirDlgChange)" />
 
-                {% if cookiecutter.create_desktop_shortcut -%}
                 <Control
                     Id="DesktopShortcutCheck"
                     X="20" Y="160" Width="290" Height="15"
                     Type="CheckBox"
                     Property="DESKTOP_SHORTCUT"
-                    CheckBoxValue="1"
+                    CheckBoxValue="{% if cookiecutter.create_desktop_shortcut -%}1{% else %}0{%- endif %}"
                     Text="Create a desktop shortcut" />
-                {%- endif %}
 
                 <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="373" Height="0" />
                 <Control

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -198,9 +198,8 @@
             Id="DesktopShortcutFeature"
             Title="Desktop Shortcut"
             Description="Create a shortcut on the desktop"
-            Level="1"
+            Display="hidden"
         >
-            <Level Condition="DESKTOP_SHORTCUT &lt;&gt; &quot;1&quot;" Value="0" />
             <ComponentRef Id="DesktopShortcut" />
         </Feature>
 
@@ -237,7 +236,7 @@
             Condition="OPTION_{{ name.upper() }} &lt;&gt; &quot;1&quot;" />
         {% endfor %}
 
-        <Property Id="DESKTOP_SHORTCUT" Value="1" />
+        <Property Id="DESKTOP_SHORTCUT" Secure="yes"{% if cookiecutter.create_desktop_shortcut %} Value="1"{% endif %} />
 
         <!--
           The ALLUSERS variable has to have a value of "" or 1; we need a
@@ -432,7 +431,7 @@
                     X="20" Y="160" Width="290" Height="15"
                     Type="CheckBox"
                     Property="DESKTOP_SHORTCUT"
-                    CheckBoxValue="{% if cookiecutter.create_desktop_shortcut -%}1{% else %}0{%- endif %}"
+                    CheckBoxValue="1"
                     Text="Create a desktop shortcut" />
 
                 <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="373" Height="0" />
@@ -688,7 +687,8 @@
                 Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
-                Value="InstallOptionsDlg" />
+                Value="InstallOptionsDlg"
+                Order="99"/>
 
             <!-- Install Options -->
             <Publish
@@ -716,7 +716,8 @@
                 Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
-                Value="VerifyReadyDlg" />
+                Value="VerifyReadyDlg"
+                Order="99"/>
 
             <!-- Verify -->
             <Publish
@@ -829,7 +830,8 @@
                 Dialog="CustomInstallDirDlg"
                 Control="Next"
                 Event="NewDialog"
-                Value="InstallOptionsDlg" />
+                Value="InstallOptionsDlg"
+                Order="99"/>
 
             <!-- Install Options -->
             <Publish
@@ -891,6 +893,22 @@
                 Control="DiskUsage"
                 Event="SpawnDialog"
                 Value="DiskCostDlg" />
+
+            <!-- Desktop shortcut -->
+            <Publish
+                Dialog="CustomInstallDirDlg"
+                Control="Next"
+                Order="1"
+                Condition='DESKTOP_SHORTCUT = "1"'
+                Event="AddLocal"
+                Value="DesktopShortcutFeature" />
+            <Publish
+                Dialog="CustomInstallDirDlg"
+                Control="Next"
+                Order="2"
+                Condition='DESKTOP_SHORTCUT &lt;&gt; "1"'
+                Event="Remove"
+                Value="DesktopShortcutFeature" />
 
             <!-- Define the workflow through the uninstall dialogs.
 

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -138,7 +138,7 @@
                 <RegistryValue
                     Root="HKMU"
                     Key="Software\{{ author }}\{{ formal_name }}"
-                    Name="desktop_shortcut_installed"
+                    Name="DesktopShortcut"
                     Type="integer"
                     Value="1"
                     KeyPath="yes" />

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -124,6 +124,26 @@
         </StandardDirectory>
         {%- endif %}
 
+        {% if cookiecutter.create_desktop_shortcut -%}
+        <StandardDirectory Id="DesktopFolder">
+            <Component Id="DesktopShortcut">
+                <Shortcut
+                    Id="DesktopShortcut1"
+                    Name="{{ cookiecutter.formal_name|xml_escape }}"
+                    Icon="ProductIcon"
+                    Description="{{ cookiecutter.description | truncate(256, False) }}"
+                    Target="[INSTALLFOLDER]{{ cookiecutter.binary_path }}" />
+                <RegistryValue
+                    Root="HKMU"
+                    Key="Software\{{ (cookiecutter.author or 'Unknown Developer')|xml_escape }}\{{ cookiecutter.formal_name|xml_escape }}"
+                    Name="desktop_shortcut_installed"
+                    Type="integer"
+                    Value="1"
+                    KeyPath="yes" />
+            </Component>
+        </StandardDirectory>
+        {%- endif %}
+
         {% if cookiecutter.document_types -%}
         <SetProperty
             Id="FileAssociationProperty"
@@ -173,6 +193,18 @@
             {%- endfor %}
         </Feature>
 
+        {% if cookiecutter.create_desktop_shortcut -%}
+        <Feature
+            Id="DesktopShortcutFeature"
+            Title="Desktop Shortcut"
+            Description="Create a shortcut on the desktop"
+            Level="1"
+        >
+            <Level Condition="DESKTOP_SHORTCUT &lt;&gt; &quot;1&quot;" Value="0" />
+            <ComponentRef Id="DesktopShortcut" />
+        </Feature>
+        {%- endif %}
+
         <!-- Custom user properties
 
           The OPTION_X property definition describes a value that can be set.
@@ -210,6 +242,10 @@
           The ALLUSERS variable has to have a value of "" or 1; we need a
           value of 0 or 1 for option output purposes.
           -->
+        {% if cookiecutter.create_desktop_shortcut -%}
+        <Property Id="DESKTOP_SHORTCUT" Value="1" />
+        {%- endif %}
+
         <Property Id="OPTION_ALLUSERS" Value="0"/>
         <SetProperty
             Id="OPTION_ALLUSERS"
@@ -421,7 +457,7 @@
                 </Control>
             </Dialog>
 
-            {% if cookiecutter.install_options %}
+            {% if cookiecutter.install_options or cookiecutter.create_desktop_shortcut %}
             <!-- Define the custom Install Options dialog -->
             <Dialog
                 Id="InstallOptionsDlg"
@@ -468,6 +504,17 @@
                     Type="Text"
                     Text="{{ option.description }}" />
                 {% endfor %}
+
+                {% if cookiecutter.create_desktop_shortcut %}
+                    {% set desktop_shortcut_y = 50 + (cookiecutter.install_options|length) * 46 %}
+                <Control
+                    Id="DesktopShortcutCheck"
+                    X="25" Y="{{ desktop_shortcut_y }}" Width="290" Height="15"
+                    Type="CheckBox"
+                    Property="DESKTOP_SHORTCUT"
+                    CheckBoxValue="1"
+                    Text="Create a desktop shortcut" />
+                {% endif %}
 
                 <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="373" Height="0" />
                 <Control
@@ -641,7 +688,7 @@
                 Event="NewDialog"
                 Value="LicenseAgreementDlg" />
 
-                {% if cookiecutter.install_options %}
+                {% if cookiecutter.install_options or cookiecutter.create_desktop_shortcut %}
 
             <Publish
                 Dialog="CustomInstallDirDlg"
@@ -782,7 +829,7 @@
                 Event="NewDialog"
                 Value="InstallScopeDlg" />
 
-                {% if cookiecutter.install_options %}
+                {% if cookiecutter.install_options or cookiecutter.create_desktop_shortcut %}
 
             <Publish
                 Dialog="CustomInstallDirDlg"

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -433,6 +433,16 @@
                     X="20" Y="120" Width="56" Height="17"
                     Text="!(loc.InstallDirDlgChange)" />
 
+                {% if cookiecutter.create_desktop_shortcut -%}
+                <Control
+                    Id="DesktopShortcutCheck"
+                    X="20" Y="160" Width="290" Height="15"
+                    Type="CheckBox"
+                    Property="DESKTOP_SHORTCUT"
+                    CheckBoxValue="1"
+                    Text="Create a desktop shortcut" />
+                {%- endif %}
+
                 <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="373" Height="0" />
                 <Control
                     Id="DiskUsage"
@@ -460,7 +470,7 @@
                 </Control>
             </Dialog>
 
-            {% if cookiecutter.install_options or cookiecutter.create_desktop_shortcut %}
+            {% if cookiecutter.install_options %}
             <!-- Define the custom Install Options dialog -->
             <Dialog
                 Id="InstallOptionsDlg"
@@ -507,17 +517,6 @@
                     Type="Text"
                     Text="{{ option.description }}" />
                 {% endfor %}
-
-                {% if cookiecutter.create_desktop_shortcut %}
-                    {% set desktop_shortcut_y = 50 + (cookiecutter.install_options|length) * 46 %}
-                <Control
-                    Id="DesktopShortcutCheck"
-                    X="25" Y="{{ desktop_shortcut_y }}" Width="290" Height="15"
-                    Type="CheckBox"
-                    Property="DESKTOP_SHORTCUT"
-                    CheckBoxValue="1"
-                    Text="Create a desktop shortcut" />
-                {% endif %}
 
                 <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="373" Height="0" />
                 <Control
@@ -691,7 +690,7 @@
                 Event="NewDialog"
                 Value="LicenseAgreementDlg" />
 
-                {% if cookiecutter.install_options or cookiecutter.create_desktop_shortcut %}
+                {% if cookiecutter.install_options %}
 
             <Publish
                 Dialog="CustomInstallDirDlg"
@@ -832,7 +831,7 @@
                 Event="NewDialog"
                 Value="InstallScopeDlg" />
 
-                {% if cookiecutter.install_options or cookiecutter.create_desktop_shortcut %}
+                {% if cookiecutter.install_options %}
 
             <Publish
                 Dialog="CustomInstallDirDlg"


### PR DESCRIPTION
This adds an option to create a desktop shortcut. The option is only shown if the `create_desktop_shortcut` config is enabled.

(Will follow up with a Briefcase PR if this is accepted).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Sonnet 4.6 + Fable 5
