### PR TITLE
Fix PRE_UNINSTALL_CMD not set before REMOVE=ALL is finalized

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -1025,7 +1025,7 @@
         <SetProperty
             Id="PRE_UNINSTALL_CMD"
             Value="&quot;[SystemFolder]cmd.exe&quot;  /c &quot;&quot;[INSTALLFOLDER]{{ cookiecutter.installer_path }}\run_pre_uninstall.bat&quot; [INSTALL_UNATTENDED]{% for name in cookiecutter.uninstall_options %} [OPTION_{{ name.upper() }}]{% endfor %}&quot;"
-            After="CostFinalize"
+            After="InstallValidate"
             Sequence="execute"
             Condition='REMOVE="ALL"' />
 


### PR DESCRIPTION
## Description
With `briefcase 0.4.4` (and `0.4.3`) I had this error when I try to uninstall (by doube-clicking the MSI file):
<img width="575" height="289" alt="image" src="https://github.com/user-attachments/assets/8e53181d-22b3-40f7-9f70-6f1ab5a21649" />
However, it did work to uninstall via the command line using `msiexec /x ...`.
I started debugging this issue with the help of using the MSI engine log-files and Claude Code, comparing the log-files and looking at recent changes in the WiX template. Eventually I arrived at the fix in this PR.

## The bug
The pre-uninstall command line is built by a `SetProperty` in the WiX template, gated on `Condition='REMOVE="ALL"'` and scheduled `After="CostFinalize"`. The problem: `REMOVE` isn't actually `"ALL"` yet at that point — it's only set to `"ALL"` by the built-in `InstallValidate` action, which runs *later* in the sequence.

Command-line `msiexec /x` isn't affected because `REMOVE` is already `"ALL"` from the start. But the **maintenance/repair UI** (what you get double-clicking an installed MSI and choosing "Remove") starts with `REMOVE="DefaultFeature"`, only flipping to `"ALL"` once `InstallValidate` runs. Since `SetPRE_UNINSTALL_CMD` executes *before* that, its condition is false, and `PRE_UNINSTALL_CMD` is left empty.

The actual uninstall action (`PreUninstallActionInteractive`) runs later and does see `REMOVE="ALL"`, but it's a **deferred** custom action — it queues up whatever `PRE_UNINSTALL_CMD` was at that earlier point (empty), then replays it during `InstallFinalize`. Running a blank command triggers Windows Installer error 1721, rollback, and the generic failure dialog (1603) — reproducing exactly what happens on double-click uninstall.

## The fix

Change the `SetProperty`'s anchor from `After="CostFinalize"` to `After="InstallValidate"`, so it runs after `REMOVE` is actually `"ALL"`, but still before the deferred action consumes it. Verified via a fresh verbose install log: `PRE_UNINSTALL_CMD` now resolves correctly, and the maintenance-UI uninstall completes without error.

I haven't tested other solutions, however when I prompt Claude for all possible solutions:
1. Move the anchor — reschedule `SetPRE_UNINSTALL_CMD` from `After="CostFinalize"` to `After="InstallValidate"` so it runs once `REMOVE` is actually `"ALL"` (the fix that's part of this PR).
2. Drop the redundant condition — `remove Condition='REMOVE="ALL"` from `SetPRE_UNINSTALL_CMD` entirely, since the consuming custom actions already gate on that condition themselves.
3. Compute the command inline — build the `PRE_UNINSTALL_CMD` string immediately before the deferred action runs instead of as an earlier separate property-setter.
4. Use an explicit `Schedule` anchor — functionally equivalent to option 1, just expressed via a different WiX scheduling mechanism instead of `After=`.

## Local testing
I've tested the fix locally by building an installer and:
1. Install by double clicking the `.msi` file -> uninstall by double clicking the `.msi` file 
2. Install by double clicking the `.msi` file  -> uninstall via the Add/Remove Programs Menu
3. Install by double clicking the `.msi` file  -> uninstall via `cmd.exe` (`msiexec /x "Name of my installer"`).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: Claude Sonnet 5.0
