### PR TITLE
Merge Dependabot updates into multi-ecosystem group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,21 @@
 version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+multi-ecosystem-groups:
+  dependencies:
     schedule:
       # Check for updates on the first Sunday of every month, 8PM UTC
       interval: "cron"
       cronjob: "0 20 * * sun#1"
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependencies"
     cooldown:
       default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
-    schedule:
-      # Check for updates on the first Sunday of every month, 8PM UTC
-      interval: "cron"
-      cronjob: "0 20 * * sun#1"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependencies"
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,12 @@
 version: 2
+
 multi-ecosystem-groups:
   dependencies:
     schedule:
       # Check for updates on the first Sunday of every month, 8PM UTC
       interval: "cron"
       cronjob: "0 20 * * sun#1"
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This change merges the GitHub Actions and pre-commit Dependabot configurations into a single `dependencies` multi-ecosystem group.

The updated configuration:

- groups GitHub Actions and pre-commit dependency updates
- uses `patterns: ["*"]` to include all dependencies
- preserves the existing first-Sunday monthly schedule
- preserves the existing 7-day cooldown

This reduces the number of separate Dependabot update pull requests generated by the repository.

Fixes #105

## Validation

- Parsed `.github/dependabot.yml` successfully as YAML
- Ran `git diff --check`

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: OpenAI ChatGPT