### PR TITLE
ci: add zizmor pre-commit hook

### DIFF
--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   check-pr-template:
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@main
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@d36f8fe66673484b598317adaab0433518b122f6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -21,7 +24,7 @@ env:
 jobs:
   pre-commit:
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@d36f8fe66673484b598317adaab0433518b122f6
     with:
       pre-commit-source: pre-commit
 
@@ -29,7 +32,9 @@ jobs:
     name: Verify min_os_version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - run: |
           target_windows_build=$(grep -oP 'target_windows_build = \K\d+' "{{ cookiecutter.format }}/briefcase.toml")
           min_os_version=$(grep -oP '"min_os_version": "\K\d+(?=")' "cookiecutter.json")
@@ -41,7 +46,7 @@ jobs:
   verify-apps:
     name: Build apps
     needs: [pre-commit, verify-min-os-version]
-    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
+    uses: beeware/.github/.github/workflows/app-build-verify.yml@d36f8fe66673484b598317adaab0433518b122f6
     with:
       python-version: ${{ matrix.python-version }}
       runner-os: ${{ matrix.runs-on }}

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -11,8 +11,11 @@ jobs:
   add-to-project:
     name: Add issue to BeeWare project
     runs-on: ubuntu-latest
+    # The add-to-project action authenticates with BRUTUS_PAT_TOKEN, so the
+    # job's own GITHUB_TOKEN needs no permissions.
+    permissions: {}
     steps:
-      - uses: actions/add-to-project@v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/beeware/projects/1
           github-token: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,7 @@ repos:
       - id: check-xml
       - id: check-case-conflict
       - id: trailing-whitespace
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.28.0
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: OpenAI Codex

## Summary

- add the requested zizmor pre-commit hook
- address zizmor findings in GitHub Actions workflows
- limit the patch to workflow/pre-commit hygiene

## Validation

- `git diff --check`
- `zizmor 1.28.0 --offline --no-progress .github/workflows .github/dependabot.yml`
- `zizmor 1.28.0 --offline --no-progress --format json .github/workflows .github/dependabot.yml`
- `pre-commit` not run locally because it is unavailable on this host

Closes #106

Note: this is workflow hygiene only; no security certification is claimed.