### PR TITLE
Add extra default paths to PYTHONPATH

### DIFF
--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -10,4 +10,4 @@ permissions:
 jobs:
   check-pr-template:
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@d36f8fe66673484b598317adaab0433518b122f6
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   pre-commit:
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@d36f8fe66673484b598317adaab0433518b122f6
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
     with:
       pre-commit-source: pre-commit
 
@@ -46,7 +46,7 @@ jobs:
   verify-apps:
     name: Build apps
     needs: [pre-commit, verify-min-os-version]
-    uses: beeware/.github/.github/workflows/app-build-verify.yml@d36f8fe66673484b598317adaab0433518b122f6
+    uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
       python-version: ${{ matrix.python-version }}
       runner-os: ${{ matrix.runs-on }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      # Allow BeeWare-provided actions to be unpinned. If an attacker is in a
+      # position to exploit those action, they're probably able to exploit
+      # repositories directly; and it's significantly easier for our internal
+      # actions to automatically be the most recent versions.
+      policies:
+        beeware/*: ref-pin

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -18,7 +18,7 @@ extras_path = "extras"
     "3.13": "support_revision = 14",
     "3.14": "support_revision = 6",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = "b12"
+stub_binary_revision = "12"
 icon = "icon.ico"
 {% for document_type_id, document_type in cookiecutter.document_types.items() -%}
 document_type_icon.{{ document_type_id }} = "{{ cookiecutter.app_name }}-{{ document_type_id }}.ico"

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -18,7 +18,7 @@ extras_path = "extras"
     "3.13": "support_revision = 14",
     "3.14": "support_revision = 6",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = "x2917"
+stub_binary_revision = "b12"
 icon = "icon.ico"
 {% for document_type_id, document_type in cookiecutter.document_types.items() -%}
 document_type_icon.{{ document_type_id }} = "{{ cookiecutter.app_name }}-{{ document_type_id }}.ico"

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -15,10 +15,10 @@ extras_path = "extras"
     "3.10": "support_revision = 11",
     "3.11": "support_revision = 9",
     "3.12": "support_revision = 10",
-    "3.13": "support_revision = 13",
-    "3.14": "support_revision = 4",
+    "3.13": "support_revision = 14",
+    "3.14": "support_revision = 6",
 }.get(cookiecutter.python_version|py_tag, "") }}
-stub_binary_revision = 11
+stub_binary_revision = "x2917"
 icon = "icon.ico"
 {% for document_type_id, document_type in cookiecutter.document_types.items() -%}
 document_type_icon.{{ document_type_id }} = "{{ cookiecutter.app_name }}-{{ document_type_id }}.ico"


### PR DESCRIPTION
A Conda-based Windows app will put Python code in different locations:

* The standard library is contained in the Lib subfolder.
* .pyd binaries from the standard library are in the DLLs subfolder.

As there's no real cost to adding extra paths to the PYTHONPATH, this adds the Conda-compatible paths to the stub binary. allowing the same stub to be used on both Conda and pip-based environments.

This is currently configured to use an experimental tagged binary (x2917), built using beeware/briefcase-windows-VisualStudio-template#105. That branch must be merged and re-tagged, and this PR updated to reflect the new tagged binary, before this can be merged.

Also includes an update to the zizmor configuration to relax the version pinning for beeware actions; and a bump to the support package versions.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
