### PR TITLE
Ensure wizard dialogs have consistent titles.

### DIFF
--- a/{{ cookiecutter.format }}/unicode.wxl
+++ b/{{ cookiecutter.format }}/unicode.wxl
@@ -1,11 +1,32 @@
 <WixLocalization Culture="en-US" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+
+    <String Id="WelcomeDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="LicenseAgreementDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="InstallScopeDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="InstallDirDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="CustomizeDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="VerifyReadyDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="ProgressDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="ExitDialog_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="MaintenanceWelcomeDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="CancelDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="BrowseDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="DiskCostDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="InvalidDirDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="FilesInUse_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="MsiRMFilesInUse_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="ErrorDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="FatalError_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="UserExit_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="WaitForCostingDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="PrepareDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="ResumeDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="OutOfDiskDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+    <String Id="OutOfRbDiskDlg_Title" Value="[ProductName] [DIALOG_TITLE]" />
+
     <String
         Id="InstallScopeDlgPerMachineDescription"
         Value="[ProductName] will be installed in a per-machine folder and be available for all users. You must have local Administrator privileges." />
-
-    <String
-        Id="MaintenanceWelcomeDlg_Title"
-        Value="[ProductName] Uninstallation" />
 
     <String
         Id="MaintenanceWelcomeDlgTitle"

--- a/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.app_name }}.wxs
@@ -341,6 +341,15 @@
         customization, and they have some bugs, e.g.
         https://github.com/wixtoolset/issues/issues/5908. -->
 
+        <!-- Ensure the dialog titles reflect whether this is an install or uninstall -->
+        <Property Id="DIALOG_TITLE" Value="Installation" />
+        <SetProperty
+            Id="DIALOG_TITLE"
+            Value="Uninstallation"
+            Sequence="first"
+            Before="AppSearch"
+            Condition="Installed" />
+
         <!-- Enable the radio buttons in InstallScopeDlg, and set the default value -->
         <WixVariable Id="WixUISupportPerUser" Value="1" />
         <WixVariable Id="WixUISupportPerMachine" Value="1" />
@@ -479,7 +488,7 @@
             <Dialog
                 Id="InstallOptionsDlg"
                 Width="370" Height="270"
-                Title="Install options"
+                Title="!(loc.CustomizeDlg_Title)"
                 TrackDiskSpace="no"
             >
 
@@ -495,7 +504,7 @@
                     X="15" Y="6" Width="210" Height="15"
                     Transparent="yes"
                     NoPrefix="yes"
-                    Text="!(loc.CustomizeDlgTitle)" />
+                    Text="{\WixUI_Font_Title}Customize Install" />
                 <Control
                     Id="Description"
                     Type="Text"
@@ -551,7 +560,7 @@
             <Dialog
                 Id="UninstallOptionsDlg"
                 Width="370" Height="270"
-                Title="Uninstall options"
+                Title="!(loc.CustomizeDlg_Title)"
                 TrackDiskSpace="no"
             >
 
@@ -567,7 +576,7 @@
                     X="15" Y="6" Width="210" Height="15"
                     Transparent="yes"
                     NoPrefix="yes"
-                    Text="!(loc.CustomizeDlgTitle)" />
+                    Text="{\WixUI_Font_Title}Customize Uninstall" />
                 <Control
                     Id="Description"
                     Type="Text"


### PR DESCRIPTION
Ensure that all dialogs in the install sequence have a title of "{formal name} Installation", and all dialogs in the uninstall sequence have a title of "{formal name} Uninstallation".

Previously, the install/uninstall options dialogs had an inconsistent title of "Install Options" or "Uninstall Options", and all other installation options (except the initial dialog) had a title of "{formal name} Setup".

Refs beeware/briefcase#3027

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
